### PR TITLE
sort pages naturally

### DIFF
--- a/comic2pdf.py
+++ b/comic2pdf.py
@@ -12,6 +12,7 @@ import traceback
 import pkg_resources
 import patoolib
 from PIL import Image
+from natsort import natsorted
 
 PACKAGE_NAME = "comic2pdf"
 EXTN_COMIC_ZIP = (".cbz", ".zip")
@@ -33,7 +34,7 @@ def extract_cbz(filename, tmpdirname):
 
 
 def collect_images(path):
-    for item in os.listdir(path):
+    for item in natsorted(os.listdir(path)):
         itempath = os.path.join(path, item)
         _, extn = os.path.splitext(item.lower())
         if os.path.isdir(itempath):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 patool
 pillow
 black
+natsort

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     entry_points={"console_scripts": ["comic2pdf=comic2pdf:main"]},
     license="WTFPL",
     keywords=["comic", "pdf", "cbr", "cbz", "convert"],
-    install_requires=["patool", "pillow"],
+    install_requires=["patool", "pillow", "natsort"],
     zip_safe=True,
 )


### PR DESCRIPTION
According to the [documentation](https://docs.python.org/3/library/os.html#os.listdir), 

> Return a list containing the names of the entries in the directory given by path. **The list is in arbitrary order**, and does not include the special entries

the returned list is not sorted by default.

This sorts pages naturally before building a PDF file.